### PR TITLE
Test: Allow Windows Server 2019 with SQL 2019 AMI

### DIFF
--- a/templates/mssqlfsx-mad.template.yaml
+++ b/templates/mssqlfsx-mad.template.yaml
@@ -275,6 +275,8 @@ Parameters:
     AllowedValues:
     - Windows_Server-2019-English-Full-Base*
     - Windows_Server-2016-English-Full-Base*
+    - Windows_Server-2019-English-Full-SQL_2019_Standard-2022.02.10
+    - ami-055fccfa14a72b3f1
     ConstraintDescription: Must be one of the supported Windows versions.
     Default: Windows_Server-2019-English-Full-Base*
     Description: Select Windows version to run SQL Server.

--- a/templates/mssqlfsx-mad.template.yaml
+++ b/templates/mssqlfsx-mad.template.yaml
@@ -282,7 +282,28 @@ Parameters:
   WorkloadInstanceType:
     AllowedValues:
     - t3a.2xlarge
+    - t3a.xlarge
+    - t3a.large
+    - t3a.medium
+    - t3a.small
     - t3.2xlarge
+    - t3.xlarge
+    - t3.large
+    - t3.medium
+    - t3.small
+    - m6i.8xlarge
+    - m6i.2xlarge
+    - m6i.xlarge
+    - m6i.large
+    - m5a.8xlarge
+    - m5a.4xlarge   
+    - m5a.2xlarge
+    - m5a.xlarge
+    - m5a.large
+    - m5.8xlarge
+    - m5.2xlarge
+    - m5.xlarge
+    - m5.large
     - r5a.xlarge
     - r5a.2xlarge
     - r5a.4xlarge

--- a/templates/mssqlfsx-main.template.yaml
+++ b/templates/mssqlfsx-main.template.yaml
@@ -524,6 +524,8 @@ Parameters:
     AllowedValues:
     - Windows_Server-2019-English-Full-Base*
     - Windows_Server-2016-English-Full-Base*
+    - Windows_Server-2019-English-Full-SQL_2019_Standard-2022.02.10
+    - ami-055fccfa14a72b3f1
     ConstraintDescription: Must be one of the supported Windows versions.
     Default: Windows_Server-2019-English-Full-Base*
     Description: Choose the Windows version to run SQL Server.

--- a/templates/mssqlfsx-main.template.yaml
+++ b/templates/mssqlfsx-main.template.yaml
@@ -427,7 +427,28 @@ Parameters:
   WorkloadInstanceType:
     AllowedValues:
     - t3a.2xlarge
+    - t3a.xlarge
+    - t3a.large
+    - t3a.medium
+    - t3a.small
     - t3.2xlarge
+    - t3.xlarge
+    - t3.large
+    - t3.medium
+    - t3.small
+    - m6i.8xlarge
+    - m6i.2xlarge
+    - m6i.xlarge
+    - m6i.large
+    - m5a.8xlarge
+    - m5a.4xlarge   
+    - m5a.2xlarge
+    - m5a.xlarge
+    - m5a.large
+    - m5.8xlarge
+    - m5.2xlarge
+    - m5.xlarge
+    - m5.large
     - r5a.xlarge
     - r5a.2xlarge
     - r5a.4xlarge

--- a/templates/mssqlfsx-main.template.yaml
+++ b/templates/mssqlfsx-main.template.yaml
@@ -176,15 +176,49 @@ Parameters:
     Type: String
   ADServer1InstanceType:
     AllowedValues:
+      - t3a.2xlarge
+      - t3a.xlarge
+      - t3a.large
+      - t3a.medium
+      - t3a.small
+      - t3.2xlarge
+      - t3.xlarge
+      - t3.large
+      - t3.medium
+      - t3.small
       - t2.large
-      - m4.large
-      - m4.xlarge
-      - m4.2xlarge
-      - m4.4xlarge
-      - m5.large
-      - m5.xlarge
-      - m5.2xlarge
+      - t2.medium
+      - t2.small
+      - m6i.8xlarge
+      - m6i.4xlarge
+      - m6i.2xlarge
+      - m6i.xlarge
+      - m6i.large
+      - m5a.8xlarge
+      - m5a.4xlarge   
+      - m5a.2xlarge
+      - m5a.xlarge
+      - m5a.large
+      - m5.8xlarge
       - m5.4xlarge
+      - m5.2xlarge
+      - m5.xlarge
+      - m5.large
+      - r5a.xlarge
+      - r5a.2xlarge
+      - r5a.4xlarge
+      - r5a.8xlarge
+      - r5.large
+      - r5.xlarge
+      - r5.2xlarge
+      - r5.4xlarge
+      - r5.8xlarge
+      - r4.xlarge
+      - r4.2xlarge
+      - r4.4xlarge
+      - r4.8xlarge
+      - z1d.large
+      - z1d.xlarge  
     Default: m5.xlarge
     Description: Amazon EC2 instance type for the first Active Directory instance, located in Availability Zone 1.
     Type: String
@@ -203,15 +237,49 @@ Parameters:
     Type: String
   ADServer2InstanceType:
     AllowedValues:
+      - t3a.2xlarge
+      - t3a.xlarge
+      - t3a.large
+      - t3a.medium
+      - t3a.small
+      - t3.2xlarge
+      - t3.xlarge
+      - t3.large
+      - t3.medium
+      - t3.small
       - t2.large
-      - m4.large
-      - m4.xlarge
-      - m4.2xlarge
-      - m4.4xlarge
-      - m5.large
-      - m5.xlarge
-      - m5.2xlarge
+      - t2.medium
+      - t2.small
+      - m6i.8xlarge
+      - m6i.4xlarge
+      - m6i.2xlarge
+      - m6i.xlarge
+      - m6i.large
+      - m5a.8xlarge
+      - m5a.4xlarge   
+      - m5a.2xlarge
+      - m5a.xlarge
+      - m5a.large
+      - m5.8xlarge
       - m5.4xlarge
+      - m5.2xlarge
+      - m5.xlarge
+      - m5.large
+      - r5a.xlarge
+      - r5a.2xlarge
+      - r5a.4xlarge
+      - r5a.8xlarge
+      - r5.large
+      - r5.xlarge
+      - r5.2xlarge
+      - r5.4xlarge
+      - r5.8xlarge
+      - r4.xlarge
+      - r4.2xlarge
+      - r4.4xlarge
+      - r4.8xlarge
+      - z1d.large
+      - z1d.xlarge  
     Default: m5.xlarge
     Description: Amazon EC2 instance type for the second Active Directory instance, located in Availability Zone 2.
     Type: String
@@ -361,13 +429,49 @@ Parameters:
     Type: String
   RDGWInstanceType:
     AllowedValues:
-      - t2.small
-      - t2.medium
+      - t3a.2xlarge
+      - t3a.xlarge
+      - t3a.large
+      - t3a.medium
+      - t3a.small
+      - t3.2xlarge
+      - t3.xlarge
+      - t3.large
+      - t3.medium
+      - t3.small
       - t2.large
-      - m5.large
-      - m5.xlarge
-      - m5.2xlarge
+      - t2.medium
+      - t2.small
+      - m6i.8xlarge
+      - m6i.4xlarge
+      - m6i.2xlarge
+      - m6i.xlarge
+      - m6i.large
+      - m5a.8xlarge
+      - m5a.4xlarge   
+      - m5a.2xlarge
+      - m5a.xlarge
+      - m5a.large
+      - m5.8xlarge
       - m5.4xlarge
+      - m5.2xlarge
+      - m5.xlarge
+      - m5.large
+      - r5a.xlarge
+      - r5a.2xlarge
+      - r5a.4xlarge
+      - r5a.8xlarge
+      - r5.large
+      - r5.xlarge
+      - r5.2xlarge
+      - r5.4xlarge
+      - r5.8xlarge
+      - r4.xlarge
+      - r4.2xlarge
+      - r4.4xlarge
+      - r4.8xlarge
+      - z1d.large
+      - z1d.xlarge    
     Default: t2.large
     Description: Amazon EC2 instance type for the Remote Desktop Gateway instances.
     Type: String

--- a/templates/mssqlfsx.template.yaml
+++ b/templates/mssqlfsx.template.yaml
@@ -292,6 +292,7 @@ Parameters:
     - t3.medium
     - t3.small
     - m6i.8xlarge
+    - m6i.4xlarge
     - m6i.2xlarge
     - m6i.xlarge
     - m6i.large
@@ -301,6 +302,7 @@ Parameters:
     - m5a.xlarge
     - m5a.large
     - m5.8xlarge
+    - m5.4large
     - m5.2xlarge
     - m5.xlarge
     - m5.large

--- a/templates/mssqlfsx.template.yaml
+++ b/templates/mssqlfsx.template.yaml
@@ -282,7 +282,28 @@ Parameters:
   WorkloadInstanceType:
     AllowedValues:
     - t3a.2xlarge
+    - t3a.xlarge
+    - t3a.large
+    - t3a.medium
+    - t3a.small
     - t3.2xlarge
+    - t3.xlarge
+    - t3.large
+    - t3.medium
+    - t3.small
+    - m6i.8xlarge
+    - m6i.2xlarge
+    - m6i.xlarge
+    - m6i.large
+    - m5a.8xlarge
+    - m5a.4xlarge   
+    - m5a.2xlarge
+    - m5a.xlarge
+    - m5a.large
+    - m5.8xlarge
+    - m5.2xlarge
+    - m5.xlarge
+    - m5.large
     - r5a.xlarge
     - r5a.2xlarge
     - r5a.4xlarge

--- a/templates/mssqlfsx.template.yaml
+++ b/templates/mssqlfsx.template.yaml
@@ -273,6 +273,8 @@ Parameters:
     AllowedValues:
     - Windows_Server-2019-English-Full-Base*
     - Windows_Server-2016-English-Full-Base*
+    - Windows_Server-2019-English-Full-SQL_2019_Standard-2022.02.10
+    - ami-055fccfa14a72b3f1
     ConstraintDescription: Must be one of the supported Windows versions.
     Default: Windows_Server-2019-English-Full-Base*
     Description: Select Windows version to run SQL Server.


### PR DESCRIPTION
For testing:
Add Windows_Server-2019-English-Full-SQL_2019_Standard-2022.02.10 as an allowed WindowsVersion
And AMI ami-055fccfa14a72b3f1, which is the same.